### PR TITLE
Parse Avro request bodies into the parameters hash

### DIFF
--- a/lib/avro_turf/rails/avro_helpers.rb
+++ b/lib/avro_turf/rails/avro_helpers.rb
@@ -1,0 +1,33 @@
+module AvroTurf::Rails::AvroHelpers
+  extend ActiveSupport::Concern
+
+  included do
+    before_filter :decode_avro_params
+  end
+
+  def avro_schema
+    self.class.schema
+  end
+
+  private
+
+  def decode_avro_params
+    schema_name = avro_schema
+
+    return unless request.content_mime_type.avro?
+    return if request.body.eof?
+    return if schema_name.nil?
+    return unless request.post? || request.put?
+
+    avro = AvroTurf.new(schemas_path: Rails.root.join("app/schemas"))
+    decoded_data = avro.decode(request.body.string, schema_name: schema_name)
+    params[schema_name] = decoded_data
+  end
+
+  module ClassMethods
+    def schema(name = nil)
+      @avro_schema = name.to_s if name
+      @avro_schema
+    end
+  end
+end

--- a/lib/avro_turf/rails/railtie.rb
+++ b/lib/avro_turf/rails/railtie.rb
@@ -1,8 +1,12 @@
+require 'avro_turf/rails/avro_helpers'
+
 class AvroTurf
   module Rails
     class Railtie < ::Rails::Railtie
       initializer 'avro_turf.initialize_avro_serialization' do
         Mime::Type.register "avro/binary", :avro
+
+        ActionController::Base.send(:include, AvroTurf::Rails::AvroHelpers)
 
         avro = AvroTurf.new(schemas_path: ::Rails.root.join("app", "schemas"))
 

--- a/spec/dummy/app/controllers/groups_controller.rb
+++ b/spec/dummy/app/controllers/groups_controller.rb
@@ -1,0 +1,15 @@
+class GroupsController < ApplicationController
+  schema :group
+
+  def create
+    @group = params.fetch(:group)
+
+    raise unless @group.key?(:name)
+
+    head :created
+  end
+
+  def update
+    head :ok
+  end
+end

--- a/spec/dummy/app/schemas/group.avsc
+++ b/spec/dummy/app/schemas/group.avsc
@@ -1,0 +1,7 @@
+{
+  "name": "group",
+  "type": "record",
+  "fields": [
+    { "name": "name", "type": "string" }
+  ]
+}

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   resources :people
+  resources :groups
 end

--- a/spec/integration/parameter_decoding_spec.rb
+++ b/spec/integration/parameter_decoding_spec.rb
@@ -1,0 +1,19 @@
+# See spec/dummy/app/controllers/groups_controller.rb
+describe "Parameter decoding", type: :request do
+  let(:avro) { AvroTurf.new(schemas_path: "spec/dummy/app/schemas") }
+
+  it "decodes request bodies encoded with Avro" do
+    data = { "name" => "VIP" }
+    body = avro.encode(data, schema_name: "group")
+
+    post "/groups", body, { "Content-Type" => "avro/binary" }
+
+    expect(response.status).to eq 201
+  end
+
+  it "ignores empty request bodies" do
+    put "/groups/42", nil, { "Content-Type" => "avro/binary" }
+
+    expect(response.status).to eq 200
+  end
+end


### PR DESCRIPTION
Allows enforcing a schema when parsing requests while making it easy to get to the params.
